### PR TITLE
Particles story improvement

### DIFF
--- a/src/stories/Particles.jsx
+++ b/src/stories/Particles.jsx
@@ -1,46 +1,52 @@
-import React from 'react';
-import ReactParticles from 'react-particles';
-import PropTypes from 'prop-types';
+import React from "react";
+import ReactParticles from "react-particles";
+import PropTypes from "prop-types";
 import { loadFull } from "tsparticles";
 
-export const Particles = ({ backgroundColor, particlesColor, links }) => {
-    const particlesInit = async (engine) => {
-        await loadFull(engine);
-    };
+export const Particles = ({
+  backgroundColor,
+  particlesColor,
+  links,
+  linkColor,
+}) => {
+  const particlesInit = async (engine) => {
+    await loadFull(engine);
+  };
 
-    return (
-        <ReactParticles
-            init={particlesInit}
-            options={{
-                background: {
-                    color: {
-                        value: backgroundColor,
-                    }
-                },
-                particles: {
-                    color: {
-                        value: particlesColor,
-                    },
-                    links: {
-                        enable: links
-                    },
-                    move: {
-                        enable: true,
-                    }
-                }
-            }}
-        />
-    );
+  return (
+    <ReactParticles
+      init={particlesInit}
+      options={{
+        background: {
+          color: {
+            value: backgroundColor,
+          },
+        },
+        particles: {
+          color: {
+            value: particlesColor,
+          },
+          links: {
+            enable: links,
+            color: linkColor,
+          },
+          move: {
+            enable: true,
+          },
+        },
+      }}
+    />
+  );
 };
 
 Particles.propTypes = {
-    backgroundColor: PropTypes.string,
-    links: PropTypes.bool,
-    particlesColors: PropTypes.arrayOf(PropTypes.string),
+  backgroundColor: PropTypes.string,
+  links: PropTypes.bool,
+  particlesColors: PropTypes.arrayOf(PropTypes.string),
 };
 
 Particles.defaultProps = {
-    backgroundColor: "#000",
-    links: true,
-    particlesColors: [ "#fff" ]
+  backgroundColor: "#000",
+  links: true,
+  particlesColors: ["#fff"],
 };

--- a/src/stories/Particles.stories.jsx
+++ b/src/stories/Particles.stories.jsx
@@ -1,17 +1,18 @@
-import React from 'react';
+import React from "react";
 
-import { Particles } from './Particles';
+import { Particles } from "./Particles";
 
 // More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 export default {
-    title: 'tsParticles/Particles',
-    component: Particles,
-    // More on argTypes: https://storybook.js.org/docs/react/api/argtypes
-    argTypes: {
-        backgroundColor: { control: 'color' },
-        links: { control: 'boolean' },
-        particlesColors: { control: 'object' },
-    },
+  title: "tsParticles/Particles",
+  component: Particles,
+  // More on argTypes: https://storybook.js.org/docs/react/api/argtypes
+  argTypes: {
+    backgroundColor: { control: "color" },
+    links: { control: "boolean" },
+    particlesColors: { control: "object" },
+    linkColor: { control: "color" },
+  },
 };
 
 // More on component templates: https://storybook.js.org/docs/react/writing-stories/introduction#using-args
@@ -20,14 +21,16 @@ const Template = (args) => <Particles {...args} />;
 export const Default = Template.bind({});
 // More on args: https://storybook.js.org/docs/react/writing-stories/args
 Default.args = {
-    backgroundColor: "#000",
-    links: true,
-    particlesColors: ["#fff"]
+  backgroundColor: "#000",
+  links: true,
+  particlesColors: ["#fff"],
+  linkColor: "#fff",
 };
 
 export const Inverse = Template.bind({});
 Inverse.args = {
-    backgroundColor: "#fff",
-    links: true,
-    particlesColor: ["#000"]
+  backgroundColor: "#fff",
+  links: true,
+  particlesColor: ["#000"],
+  linkColor: "#000",
 };


### PR DESCRIPTION
As there are no links visible on particles story I think adding a new variable of linkColor would make it just fine.
Before:
<img width="884" alt="Screenshot 2022-10-25 at 22 37 33" src="https://user-images.githubusercontent.com/63009299/197803620-ef0c9c2e-6da4-4ba6-851c-29c25d402da5.png">
After:
<img width="1512" alt="Screenshot 2022-10-25 at 22 38 33" src="https://user-images.githubusercontent.com/63009299/197803888-91ca7a69-2dd8-4c81-be60-10b9d6fbc7e0.png">
